### PR TITLE
Include config.h in cpellout.cxx to get HAVE_BOOST_REGEX

### DIFF
--- a/src/spellout.cxx
+++ b/src/spellout.cxx
@@ -1,3 +1,4 @@
+#include "config.h"
 #include "Numbertext.hxx"
 #include "numbertext-version.h"
 #include <cstring>


### PR DESCRIPTION
Required for compiling on Centos 7 and supplying the --enable-boost option to configure